### PR TITLE
[refactor] 길드 게시판 목록 조회 N+1 문제 해결

### DIFF
--- a/src/main/java/com/ll/playon/domain/guild/guildBoard/repository/GuildBoardCommentRepository.java
+++ b/src/main/java/com/ll/playon/domain/guild/guildBoard/repository/GuildBoardCommentRepository.java
@@ -4,12 +4,21 @@ import com.ll.playon.domain.guild.guildBoard.entity.GuildBoard;
 import com.ll.playon.domain.guild.guildBoard.entity.GuildBoardComment;
 import com.ll.playon.domain.guild.guildMember.entity.GuildMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 
 public interface GuildBoardCommentRepository extends JpaRepository<GuildBoardComment, Long> {
     List<GuildBoardComment> findByBoardOrderByCreatedAtAsc(GuildBoard board);
-    int countByBoard(GuildBoard board);
     List<GuildBoardComment> comment(String comment);
     void deleteByAuthor(GuildMember author);
+    @Query("""
+    SELECT gbc.board.id, COUNT(gbc.id)
+    FROM GuildBoardComment gbc
+    WHERE gbc.board.id IN :boardIds
+    GROUP BY gbc.board.id
+""")
+    Map<Long, Long> countByBoardIds(@Param("boardIds") List<Long> boardIds);
 }

--- a/src/main/java/com/ll/playon/domain/guild/guildBoard/service/GuildBoardService.java
+++ b/src/main/java/com/ll/playon/domain/guild/guildBoard/service/GuildBoardService.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -53,9 +54,18 @@ public class GuildBoardService {
 
         Page<GuildBoard> boards = guildBoardRepository.searchWithFilter(guild, tag, keyword, pageable);
 
+        List<Long> boardIds = boards.getContent().stream()
+                .map(GuildBoard::getId)
+                .toList();
+
+        Map<Long, Long> commentCountMap = boardIds.isEmpty()
+                ? Map.of()
+                : guildBoardCommentRepository.countByBoardIds(boardIds);
+
+
         return boards.map(board -> {
-            int commentCount = guildBoardCommentRepository.countByBoard(board);
-            return GuildBoardSummaryResponse.from(board, commentCount, actor);
+            Long commentCount = commentCountMap.getOrDefault(board.getId(), 0L);
+            return GuildBoardSummaryResponse.from(board, commentCount.intValue(), actor);
         });
     }
 


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #1  -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
게시글 목록 조회 API에서 댓글 수 계산 로직을 개선했습니다.

기존: 게시글 N개 조회 후 각 게시글별 댓글 수 count 쿼리 실행 → N+1 발생
변경: 게시글 id 리스트를 기반으로 IN (:boardIds) GROUP BY boardId 집계 쿼리 1회 실행 → 쿼리 2회로 고정

댓글 수를 Map(boardId, count) 형태로 변환해 각 게시글 요약 응답에 주입했습니다.
