### PR TITLE
[fix] 길드 가입 승인 시, 동시성 문제 해결

### DIFF
--- a/src/main/java/com/ll/playon/domain/guild/guild/repository/GuildRepository.java
+++ b/src/main/java/com/ll/playon/domain/guild/guild/repository/GuildRepository.java
@@ -1,9 +1,11 @@
 package com.ll.playon.domain.guild.guild.repository;
 
 import com.ll.playon.domain.guild.guild.entity.Guild;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -24,4 +26,8 @@ public interface GuildRepository extends JpaRepository<Guild, Long>, GuildReposi
 
     @Query("SELECT g FROM Guild g WHERE g.game.appid = :appid AND g.isDeleted = false AND g.isPublic = true ORDER BY g.id DESC")
     List<Guild> findTopNByGameAppid(@Param("appid") Long appid, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT g FROM Guild g WHERE g.id = :guildId")
+    Optional<Guild> findByIdWithLock(@Param("guildId") Long guildId);
 }

--- a/src/main/java/com/ll/playon/domain/guild/guildJoinRequest/repository/GuildJoinRequestRepository.java
+++ b/src/main/java/com/ll/playon/domain/guild/guildJoinRequest/repository/GuildJoinRequestRepository.java
@@ -21,3 +21,4 @@ public interface GuildJoinRequestRepository extends JpaRepository<GuildJoinReque
     @Query("SELECT gjr FROM GuildJoinRequest gjr WHERE gjr.id = :requestId")
     Optional<GuildJoinRequest> findByIdWithLock(@Param("requestId") Long requestId);
 }
+

--- a/src/main/java/com/ll/playon/domain/guild/guildJoinRequest/repository/GuildJoinRequestRepository.java
+++ b/src/main/java/com/ll/playon/domain/guild/guildJoinRequest/repository/GuildJoinRequestRepository.java
@@ -4,11 +4,20 @@ import com.ll.playon.domain.member.entity.Member;
 import com.ll.playon.domain.guild.guild.entity.Guild;
 import com.ll.playon.domain.guild.guildJoinRequest.entity.GuildJoinRequest;
 import com.ll.playon.domain.guild.guildJoinRequest.enums.ApprovalState;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GuildJoinRequestRepository extends JpaRepository<GuildJoinRequest, Long> {
     boolean existsByGuildAndMemberAndApprovalState(Guild guild, Member member, ApprovalState approvalState);
     List<GuildJoinRequest> findAllByGuildAndApprovalState(Guild guild, ApprovalState approvalState);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT gjr FROM GuildJoinRequest gjr WHERE gjr.id = :requestId")
+    Optional<GuildJoinRequest> findByIdWithLock(@Param("requestId") Long requestId);
 }

--- a/src/main/java/com/ll/playon/domain/guild/guildJoinRequest/service/GuildJoinRequestService.java
+++ b/src/main/java/com/ll/playon/domain/guild/guildJoinRequest/service/GuildJoinRequestService.java
@@ -56,7 +56,7 @@ public class GuildJoinRequestService {
     }
 
     private void processJoinRequest(Long guildId, Long requestId, Member approver, ApprovalState targetState) {
-        GuildJoinRequest joinRequest = guildJoinRequestRepository.findById(requestId)
+        GuildJoinRequest joinRequest = guildJoinRequestRepository.findByIdWithLock(requestId)
                 .orElseThrow(ErrorCode.GUILD_JOIN_REQUEST_NOT_FOUND::throwServiceException);
 
         if (!joinRequest.getGuild().getId().equals(guildId)) {
@@ -79,13 +79,16 @@ public class GuildJoinRequestService {
         joinRequest.setApprovedBy(approver);
 
         if (targetState == ApprovalState.APPROVED) {
-            int currentMembers = (int) guildMemberRepository.countByGuildId(joinRequest.getGuild().getId());
-            if (currentMembers >= joinRequest.getGuild().getMaxMembers()) {
+            Guild guild = guildRepository.findByIdWithLock(joinRequest.getGuild().getId())
+                    .orElseThrow(ErrorCode.GUILD_NOT_FOUND::throwServiceException);
+
+            int currentMembers = (int) guildMemberRepository.countByGuildId(guild.getId());
+            if (currentMembers >= guild.getMaxMembers()) {
                 throw ErrorCode.GUILD_MEMBER_LIMIT_EXCEEDED.throwServiceException();
             }
 
             GuildMember newMember = GuildMember.builder()
-                    .guild(joinRequest.getGuild())
+                    .guild(guild)
                     .member(joinRequest.getMember())
                     .guildRole(GuildRole.MEMBER)
                     .build();


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1) 배경 / 문제
- 길드 가입 요청 승인(ApprovalState.APPROVED) 처리 시, 동시에 여러 요청이 승인되면 다음 문제가 발생할 수 있었습니다.
- countByGuildId()로 인원 수를 확인하는 순간과 guildMemberRepository.save() 사이에 다른 트랜잭션이 끼어들어 정원(maxMembers) 초과 가입이 발생
- 동일 가입 요청이 중복 처리되면 중복 멤버 생성 가능성

### 2) 해결 방법
- 길드 정원 체크 + 멤버 생성 구간을 임계영역으로 만들기 위해 DB 비관적 락(PESSIMISTIC_WRITE)을 적용했습니다.
- 길드 엔티티 조회 시 findByIdWithLock(guildId) 사용 → 해당 길드 row에 write lock 획득
- (승인/처리 로직에서) joinRequest 또한 findByIdWithLock(requestId)로 락을 걸어 동일 요청의 중복 승인 처리 방지

### 3) 기대 효과
- 동시 승인 상황에서도 길드 최대 인원 초과 가입 방지
- 동일 가입 요청이 중복 처리되는 경우에도 중복 멤버 생성 가능성 감소
- 정원 체크 로직의 신뢰도 향상 (레이스 컨디션 제거)