### PR TITLE
[refactor] 게임 상세 조회 시 N+1 문제 해결

### DIFF
--- a/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
+++ b/src/main/java/com/ll/playon/domain/game/game/repository/GameRepository.java
@@ -73,4 +73,14 @@ public interface GameRepository extends JpaRepository<SteamGame, Long>, GameRepo
             WHERE g.id IN :ids
             """)
     List<SteamGame> findSteamGameByIds(@Param("ids") List<Long> ids);
+
+    @Query("""
+            SELECT DISTINCT g
+            FROM SteamGame g
+            LEFT JOIN FETCH g.genres
+            LEFT JOIN FETCH g.screenshots
+            LEFT JOIN FETCH g.movies
+            WHERE g.appid = :appid
+            """)
+    Optional<SteamGame> findSteamGameByAppidWithDetails(@Param("appid") Long appid);
 }

--- a/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
+++ b/src/main/java/com/ll/playon/domain/game/game/service/GameService.java
@@ -125,13 +125,20 @@ public class GameService {
     public GameDetailWithPartyResponse getGameDetailWithParties(Long appid) {
         Pageable partyPageable = PageRequest.of(0, 3);
 
-        SteamGame game = gameRepository.findSteamGameByAppid(appid)
+        // Fetch Join으로 게임 상세 정보와 연관된 genres, screenshots, movies를 한 번에 조회
+        SteamGame game = gameRepository.findSteamGameByAppidWithDetails(appid)
                 .orElseThrow(ErrorCode.GAME_NOT_FOUND::throwServiceException);
 
-        Page<Party> partyPage = partyRepository.findByGame(game, partyPageable);
+        // 페이징을 위해 먼저 Party ID만 조회
+        Page<Long> partyIdPage = partyRepository.findPartyIdsByGame(game, partyPageable);
+        
+        // Fetch Join으로 파티와 연관된 partyMembers, partyTags, Member를 한 번에 조회
+        List<Party> parties = partyIdPage.isEmpty() 
+                ? List.of() 
+                : partyRepository.findPartiesWithDetailsByIds(partyIdPage.getContent());
 
-        // 완료된 파티 조회
-        List<Party> completedParties = partyRepository.findRecentCompletedPartiesWithLogs(
+        // 완료된 파티 조회 (Fetch Join으로 연관 데이터 함께 조회)
+        List<Party> completedParties = partyRepository.findRecentCompletedPartiesWithLogsAndDetails(
                         PartyStatus.COMPLETED, Pageable.unpaged()
                 ).stream()
                 .filter(p -> p.getGame().getAppid().equals(appid))
@@ -178,7 +185,7 @@ public class GameService {
 
         return GameDetailWithPartyResponse.from(
                 game,
-                partyPage.getContent(),
+                parties,
                 completedParties,
                 mvpMap,
                 playTimeMap,

--- a/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
+++ b/src/main/java/com/ll/playon/domain/party/party/repository/PartyRepository.java
@@ -219,4 +219,41 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE pr = :partyRoom
             """)
     Optional<Party> findByPartyRoom(@Param("partyRoom") PartyRoom partyRoom);
+
+    // 게임별 파티 ID를 페이징으로 조회 (페이징 전용)
+    @Query("""
+        SELECT p.id
+        FROM Party p
+        WHERE p.game = :game
+        """)
+    Page<Long> findPartyIdsByGame(@Param("game") SteamGame game, Pageable pageable);
+
+    // ID 리스트로 파티 + 연관 데이터 Fetch Join 조회 (N+1 방지용)
+    @Query("""
+        SELECT DISTINCT p
+        FROM Party p
+        LEFT JOIN FETCH p.partyMembers pm
+        LEFT JOIN FETCH pm.member
+        LEFT JOIN FETCH p.partyTags
+        WHERE p.id IN :partyIds
+        ORDER BY p.createdAt DESC
+        """)
+    List<Party> findPartiesWithDetailsByIds(@Param("partyIds") List<Long> partyIds);
+
+    // 완료된 공개 파티를 연관 데이터까지 Fetch Join으로 조회 (N+1 방지용)
+    @Query("""
+        SELECT DISTINCT p
+        FROM Party p
+        LEFT JOIN FETCH p.partyMembers pm
+        LEFT JOIN FETCH pm.member
+        LEFT JOIN FETCH p.partyTags
+        WHERE p.publicFlag = true
+        AND p.partyStatus = :partyStatus
+        AND pm.partyLog IS NOT NULL
+        ORDER BY p.endedAt DESC
+        """)
+    List<Party> findRecentCompletedPartiesWithLogsAndDetails(
+            @Param("partyStatus") PartyStatus partyStatus,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
### 1) 배경 / 문제
- 게임 상세 페이지에서 **게임 상세 정보(genres, screenshots, movies)** 와
  **진행중 파티 목록(페이징)**, **완료된 파티 목록**을 함께 조회하는 API가 있었습니다.
- 조회 이후 응답 DTO를 생성하는 과정에서 연관 컬렉션/엔티티 접근이 반복되며 **N+1 쿼리**가 발생했습니다.
  - SteamGame: `genres`, `screenshots`, `movies`가 LAZY 로딩 상태에서 DTO 변환 시 접근 → 컬렉션마다 추가 쿼리 발생 가능
  - Party: DTO 변환 과정에서 `partyMembers`, `member`, `partyTags` 접근이 반복 → 파티 건수만큼 추가 쿼리 증가

### 2) 해결 방법
- **게임 상세 조회 최적화**
  - SteamGame 조회 시 `genres/screenshots/movies`를 `Fetch Join`으로 한 번에 로딩하도록
    `findSteamGameByAppidWithDetails(appid)` 쿼리를 추가/적용했습니다.
- **파티 목록 조회 최적화(페이징 유지)**
  - 페이징을 유지하기 위해 조회를 2단계로 분리했습니다.
    1) `Page<Long>`으로 Party ID만 페이징 조회: `findPartyIdsByGame(game, pageable)`
    2) `IN (:partyIds) + DISTINCT + FETCH JOIN`으로 연관 데이터까지 한 번에 조회:
       `findPartiesWithDetailsByIds(ids)` (partyMembers/member/partyTags)
- **완료된 파티 조회 최적화**
  - 완료 파티도 DTO 변환 시 N+1이 발생하므로, 연관 데이터를 포함해 한 번에 조회하는
    `findRecentCompletedPartiesWithLogsAndDetails(...)` 쿼리를 추가/적용했습니다.

### 3) 기대 효과
- 게임 상세 + 파티/완료파티 조회 시 DTO 변환 과정에서 발생하던 **건별 추가 쿼리(N+1) 제거**
- 트래픽 증가 상황에서도 쿼리 수가 데이터 건수에 비례해 폭증하지 않아 **DB 부하 감소 및 응답 시간 안정화**
- 파티 목록은 **페이징을 유지**하면서도 필요한 연관 데이터를 한 번에 로딩하여 조회 성능 개선
